### PR TITLE
fix: preserve deleted resume sections

### DIFF
--- a/src/lib/resume-adapter.test.ts
+++ b/src/lib/resume-adapter.test.ts
@@ -136,6 +136,18 @@ describe("resume content adapter", () => {
 
     jadeResume.sections = [];
     expect(contentToJadeResume(jadeResumeToContent(jadeResume)).sections).toEqual([]);
+
+    const invalidSnapshot = jadeResumeToContent(contentToJadeResume(baseResume));
+    invalidSnapshot.editor!.sections = [{} as never];
+    expect(contentToJadeResume(invalidSnapshot).sections.map((section) => section.type)).toEqual([
+      "personal_info",
+      "education",
+      "work_experience",
+      "internship_experience",
+      "projects",
+      "certifications",
+      "self_evaluation",
+    ]);
   });
 
   it("restores editor snapshots while applying newer resume content", () => {

--- a/src/lib/resume-adapter.test.ts
+++ b/src/lib/resume-adapter.test.ts
@@ -118,6 +118,26 @@ describe("resume content adapter", () => {
     });
   });
 
+  it("keeps deleted sections and fields deleted after saving and reopening", () => {
+    const jadeResume = contentToJadeResume(baseResume);
+    const personalInfo = jadeResume.sections.find((section) => section.type === "personal_info");
+    personalInfo!.content = {
+      ...(personalInfo!.content as PersonalInfoContent),
+      website: "",
+      github: "github.com/linzeyu",
+    };
+    jadeResume.sections = jadeResume.sections.filter((section) => section.type !== "education");
+
+    const reopened = contentToJadeResume(jadeResumeToContent(jadeResume));
+    const reopenedPersonalInfo = reopened.sections.find((section) => section.type === "personal_info")?.content;
+
+    expect(reopened.sections.some((section) => section.type === "education")).toBe(false);
+    expect(reopenedPersonalInfo).toMatchObject({ website: "", github: "github.com/linzeyu" });
+
+    jadeResume.sections = [];
+    expect(contentToJadeResume(jadeResumeToContent(jadeResume)).sections).toEqual([]);
+  });
+
   it("restores editor snapshots while applying newer resume content", () => {
     const savedContent = jadeResumeToContent(contentToJadeResume(baseResume));
     const optimizedContent: ResumeContent = {

--- a/src/lib/resume-adapter.ts
+++ b/src/lib/resume-adapter.ts
@@ -263,6 +263,7 @@ function hydrateEditorSections(
   fallbackDate: Date,
 ): ResumeSection[] | null {
   if (!Array.isArray(sections)) return null;
+  if (sections.length === 0) return [];
 
   const hydrated = sections
     .filter((item) => item && typeof item.type === "string" && item.content)
@@ -277,7 +278,7 @@ function hydrateEditorSections(
       updatedAt: toDate(item.updatedAt, fallbackDate),
     }));
 
-  return hydrated.sort((a, b) => a.sortOrder - b.sortOrder);
+  return hydrated.length ? hydrated.sort((a, b) => a.sortOrder - b.sortOrder) : null;
 }
 
 function mergeEditorSections(savedSections: ResumeSection[], generatedSections: ResumeSection[]) {

--- a/src/lib/resume-adapter.ts
+++ b/src/lib/resume-adapter.ts
@@ -262,7 +262,7 @@ function hydrateEditorSections(
   resumeId: string,
   fallbackDate: Date,
 ): ResumeSection[] | null {
-  if (!Array.isArray(sections) || sections.length === 0) return null;
+  if (!Array.isArray(sections)) return null;
 
   const hydrated = sections
     .filter((item) => item && typeof item.type === "string" && item.content)
@@ -277,17 +277,13 @@ function hydrateEditorSections(
       updatedAt: toDate(item.updatedAt, fallbackDate),
     }));
 
-  return hydrated.length ? hydrated.sort((a, b) => a.sortOrder - b.sortOrder) : null;
+  return hydrated.sort((a, b) => a.sortOrder - b.sortOrder);
 }
 
 function mergeEditorSections(savedSections: ResumeSection[], generatedSections: ResumeSection[]) {
   const generatedByType = new Map(generatedSections.map((item) => [item.type, item]));
-  const savedTypes = new Set(savedSections.map((item) => item.type));
-  const merged = savedSections.map((saved) => mergeEditorSection(saved, generatedByType.get(saved.type)));
-  const missing = generatedSections.filter((item) => !savedTypes.has(item.type));
-
-  return [...merged, ...missing].map((item, index) => ({
-    ...item,
+  return savedSections.map((saved, index) => ({
+    ...mergeEditorSection(saved, generatedByType.get(saved.type)),
     sortOrder: index,
   }));
 }
@@ -307,9 +303,6 @@ function mergeEditorSection(saved: ResumeSection, generated?: ResumeSection): Re
           email: next.email,
           phone: next.phone,
           location: next.location,
-          website: next.website,
-          github: next.github,
-          customLinks: next.customLinks,
         },
       };
     }


### PR DESCRIPTION
## Summary

- Treat an empty editor section list as a valid saved state.
- Prevent generated fallback sections from restoring deleted sections.
- Preserve editor-specific personal link fields during resume hydration.
- Add regression coverage for deleted sections and fields.

## Testing

- `npm test`

Closes #5