### PR TITLE
fix: separate personal summary from self evaluation

### DIFF
--- a/src/lib/resume-adapter.test.ts
+++ b/src/lib/resume-adapter.test.ts
@@ -150,6 +150,42 @@ describe("resume content adapter", () => {
     ]);
   });
 
+  it("keeps personal summary separate from self evaluation", () => {
+    const reopened = contentToJadeResume({
+      ...baseResume,
+      profile: { ...baseResume.profile, summary: "专注后端开发。" },
+      selfReview: "",
+    });
+    const summary = reopened.sections.find((section) => section.type === "summary")?.content as
+      | { text: string }
+      | undefined;
+    const selfEvaluation = reopened.sections.find((section) => section.type === "self_evaluation")?.content as
+      | { text: string }
+      | undefined;
+
+    expect(summary?.text).toBe("专注后端开发。");
+    expect(selfEvaluation?.text).toBe("");
+
+    const edited = contentToJadeResume(baseResume);
+    const selfEvaluationSection = edited.sections.find((section) => section.type === "self_evaluation")!;
+    edited.sections = [
+      ...edited.sections.filter((section) => section.type !== "self_evaluation"),
+      {
+        ...selfEvaluationSection,
+        id: "summary",
+        type: "summary",
+        title: "个人简介",
+        content: { text: "新增的个人简介。" },
+      },
+    ];
+
+    const reopenedEditor = contentToJadeResume(jadeResumeToContent(edited));
+    expect(reopenedEditor.sections.find((section) => section.type === "summary")?.content).toEqual({
+      text: "新增的个人简介。",
+    });
+    expect(reopenedEditor.sections.some((section) => section.type === "self_evaluation")).toBe(false);
+  });
+
   it("restores editor snapshots while applying newer resume content", () => {
     const savedContent = jadeResumeToContent(contentToJadeResume(baseResume));
     const optimizedContent: ResumeContent = {

--- a/src/lib/resume-adapter.ts
+++ b/src/lib/resume-adapter.ts
@@ -34,10 +34,6 @@ export function contentToJadeResume(rawContent: ResumeContent): Resume {
   const skills = content.skills ?? [];
   const customSections = content.customSections ?? [];
   const editor = content.editor ?? {};
-  const selfEvaluationText = [content.profile.summary, content.selfReview]
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .join("\n");
 
   const generatedSections: ResumeSection[] = [
     section<PersonalInfoContent>(resumeId, "personal_info", "个人信息", 0, {
@@ -86,9 +82,16 @@ export function contentToJadeResume(rawContent: ResumeContent): Resume {
       })),
     }),
     section<SummaryContent>(resumeId, "self_evaluation", "自我评价", 6, {
-      text: selfEvaluationText,
+      text: content.selfReview,
     }),
   ];
+
+  if (content.profile.summary) {
+    generatedSections.splice(1, 0, section<SummaryContent>(resumeId, "summary", "个人简介", 1, {
+      text: content.profile.summary,
+    }));
+    generatedSections.forEach((item, index) => { item.sortOrder = index; });
+  }
 
   if (skills.length > 0) {
     generatedSections.push(
@@ -190,7 +193,7 @@ export function jadeResumeToContent(resume: Resume): ResumeContent {
       title: section.title,
       content: section.content.items.map(formatCustomItem).filter(Boolean).join("\n\n"),
     })).filter((item) => item.title && item.content),
-    selfReview: selfEvaluation?.text ?? customSections[0]?.content.items[0]?.description ?? "",
+    selfReview: selfEvaluation?.text ?? "",
   };
 }
 
@@ -401,6 +404,7 @@ function mergeEditorSection(saved: ResumeSection, generated?: ResumeSection): Re
         },
       };
     }
+    case "summary":
     case "self_evaluation":
       return {
         ...saved,


### PR DESCRIPTION
## Summary

- Map `profile.summary` only to the `Summary` section.
- Map `selfReview` only to the `Self Evaluation` section.
- Remove the unrelated custom-section fallback for `selfReview`.
- Add regression coverage for deleting `Self Evaluation`, adding `Summary`, and reopening the resume.

## Testing

- `npm test`

Closes #7