### PR TITLE
fix(resume): improve auto-growing fields, pagination, and skill layout

### DIFF
--- a/src/components/editor/fields/editable-list.tsx
+++ b/src/components/editor/fields/editable-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Plus, X } from 'lucide-react';
-import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 
 interface EditableListProps {
@@ -29,12 +29,13 @@ export function EditableList({ label, items, onChange, placeholder }: EditableLi
       <label className="text-xs font-medium text-zinc-500 dark:text-zinc-400">{label}</label>
       <div className="space-y-1.5">
         {(items || []).map((item, index) => (
-          <div key={index} className="flex items-center gap-1">
-            <Input
+          <div key={index} className="flex items-start gap-1">
+            <Textarea
               value={item}
               onChange={(e) => updateItem(index, e.target.value)}
               placeholder={placeholder}
-              className="h-8 text-sm"
+              rows={1}
+              className="min-h-8 resize-none py-1.5 text-sm leading-5"
             />
             <Button
               variant="ghost"

--- a/src/components/preview/paged-resume-preview.tsx
+++ b/src/components/preview/paged-resume-preview.tsx
@@ -3,7 +3,12 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { ResumePreview } from "@/components/preview/resume-preview";
-import { A4_HEIGHT_PX, A4_WIDTH_PX, calculateResumePagination } from "@/lib/resume-export-layout";
+import {
+  A4_HEIGHT_PX,
+  A4_WIDTH_PX,
+  calculateResumePagination,
+  collectResumePageBreakCandidates,
+} from "@/lib/resume-export-layout";
 import type { Resume } from "@/types/resume";
 
 type PagedResumePreviewProps = {
@@ -15,12 +20,14 @@ type PagedResumePreviewProps = {
 export function PagedResumePreview({ resume, zoom, smartOnePage }: PagedResumePreviewProps) {
   const measureRef = useRef<HTMLDivElement>(null);
   const [contentHeight, setContentHeight] = useState(A4_HEIGHT_PX);
+  const [breakCandidates, setBreakCandidates] = useState<number[]>([]);
 
   useLayoutEffect(() => {
     const measure = () => {
       const node = measureRef.current;
       if (!node) return;
       setContentHeight(Math.max(node.scrollHeight, Math.ceil(node.getBoundingClientRect().height), 1));
+      setBreakCandidates(collectResumePageBreakCandidates(node));
     };
 
     measure();
@@ -35,11 +42,10 @@ export function PagedResumePreview({ resume, zoom, smartOnePage }: PagedResumePr
   }, [resume]);
 
   const pagination = useMemo(() => {
-    return calculateResumePagination(contentHeight, smartOnePage);
-  }, [contentHeight, smartOnePage]);
+    return calculateResumePagination(contentHeight, smartOnePage, breakCandidates);
+  }, [breakCandidates, contentHeight, smartOnePage]);
 
   const previewScale = zoom / 100;
-  const pages = Array.from({ length: pagination.pageCount }, (_, index) => index);
 
   return (
     <div className="relative flex min-h-full justify-center p-3 md:p-5">
@@ -58,7 +64,7 @@ export function PagedResumePreview({ resume, zoom, smartOnePage }: PagedResumePr
             当前内容超过智能一页的可读范围，已保持分页预览。请删减或精简文字后再使用智能一页。
           </div>
         )}
-        {pages.map((pageIndex) => (
+        {pagination.pageSlices.map((pageSlice, pageIndex) => (
           <div key={pageIndex} className="flex flex-col items-center gap-2">
             <div
               className="origin-top-left"
@@ -77,16 +83,28 @@ export function PagedResumePreview({ resume, zoom, smartOnePage }: PagedResumePr
                 }}
               >
                 <div
-                  className="absolute left-0 top-0"
+                  className="absolute left-0 overflow-hidden"
                   style={{
                     width: A4_WIDTH_PX,
-                    left: pagination.horizontalOffset,
-                    transform: `scale(${pagination.fitScale})`,
-                    transformOrigin: "top left",
+                    top: pageSlice.topInset,
+                    height: Math.min(
+                      A4_HEIGHT_PX - pageSlice.topInset,
+                      (pageSlice.sourceEnd - pageSlice.sourceStart) * pagination.fitScale,
+                    ),
                   }}
                 >
-                  <div style={{ marginTop: -(pageIndex * A4_HEIGHT_PX) / pagination.fitScale }}>
-                    <ResumePreview resume={resume} mode="paged" />
+                  <div
+                    className="absolute top-0"
+                    style={{
+                      width: A4_WIDTH_PX,
+                      left: pagination.horizontalOffset,
+                      transform: `scale(${pagination.fitScale})`,
+                      transformOrigin: "top left",
+                    }}
+                  >
+                    <div style={{ marginTop: -pageSlice.sourceStart }}>
+                      <ResumePreview resume={resume} mode="paged" />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/preview/templates/academic.tsx
+++ b/src/components/preview/templates/academic.tsx
@@ -150,7 +150,7 @@ function AcademicSectionContent({ section, resume }: { section: any; resume: Res
         {categories.map((cat: any) => (
           <p key={cat.id} className="text-sm text-zinc-600">
             <span className="font-bold text-zinc-700">{cat.name}: </span>
-            {cat.skills?.join(', ')}
+            <span className="whitespace-pre-line">{cat.skills?.join('\n')}</span>
           </p>
         ))}
       </div>

--- a/src/components/preview/templates/architect.tsx
+++ b/src/components/preview/templates/architect.tsx
@@ -192,7 +192,7 @@ function ArchitectSectionContent({ section, resume }: { section: any; resume: Re
             >
               {cat.name}:
             </span>
-            <span style={{ color: BODY_TEXT }}>{(cat.skills || []).join(' / ')}</span>
+            <span className="whitespace-pre-line" style={{ color: BODY_TEXT }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/ats.tsx
+++ b/src/components/preview/templates/ats.tsx
@@ -142,7 +142,7 @@ function AtsSectionContent({ section, resume }: { section: any; resume: Resume }
         {categories.map((cat: any) => (
           <p key={cat.id} className="text-sm text-zinc-700">
             <span className="font-bold text-black">{cat.name}: </span>
-            {cat.skills?.join(', ')}
+            <span className="whitespace-pre-line">{cat.skills?.join('\n')}</span>
           </p>
         ))}
       </div>

--- a/src/components/preview/templates/classic.tsx
+++ b/src/components/preview/templates/classic.tsx
@@ -144,7 +144,7 @@ function SectionContent({ section, lang }: { section: any; lang?: string }) {
         {categories.map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="font-medium text-zinc-700 w-28 shrink-0">{cat.name}:</span>
-            <span className="text-zinc-600">{cat.skills?.join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{cat.skills?.join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/coder.tsx
+++ b/src/components/preview/templates/coder.tsx
@@ -435,7 +435,7 @@ function CoderMainContent({ section, resume }: { section: any; resume: Resume })
         {categories.map((cat: any) => (
           <div key={cat.id}>
             <span className="text-xs font-bold" style={{ color: BLUE }}>{cat.name}: </span>
-            <span className="text-sm text-zinc-600">{(cat.skills || []).join(' | ')}</span>
+            <span className="whitespace-pre-line text-sm text-zinc-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/compact.tsx
+++ b/src/components/preview/templates/compact.tsx
@@ -80,7 +80,7 @@ function CompactLeftContent({ section }: { section: any }) {
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id}>
             <p className="text-[10px] font-semibold text-zinc-600">{cat.name}</p>
-            <p className="text-[10px] text-zinc-500">{(cat.skills || []).join(', ')}</p>
+            <p className="whitespace-pre-line text-[10px] text-zinc-500">{(cat.skills || []).join('\n')}</p>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/consultant.tsx
+++ b/src/components/preview/templates/consultant.tsx
@@ -145,7 +145,7 @@ function ConsultantSectionContent({ section, resume }: { section: any; resume: R
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: GRAY_700 }}>{cat.name}:</span>
-            <span className="text-gray-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-gray-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/corporate.tsx
+++ b/src/components/preview/templates/corporate.tsx
@@ -138,7 +138,7 @@ function CorporateSectionContent({ section, resume }: { section: any; resume: Re
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: NAVY }}>{cat.name}:</span>
-            <span className="text-slate-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-slate-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/developer.tsx
+++ b/src/components/preview/templates/developer.tsx
@@ -145,7 +145,7 @@ function DeveloperSectionContent({ section, resume }: { section: any; resume: Re
         {(content.categories || []).map((cat: any) => (
           <div key={cat.id}>
             <span className="text-xs font-bold" style={{ color: ORANGE }}>{cat.name}: </span>
-            <span className="text-sm text-zinc-600">{(cat.skills || []).join(' | ')}</span>
+            <span className="whitespace-pre-line text-sm text-zinc-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/elegant.tsx
+++ b/src/components/preview/templates/elegant.tsx
@@ -122,7 +122,7 @@ function ElegantSectionContent({ section, lang }: { section: any; lang?: string 
         {(content.categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: GOLD }}>{cat.name}:</span>
-            <span className="text-zinc-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/euro.tsx
+++ b/src/components/preview/templates/euro.tsx
@@ -125,7 +125,7 @@ function EuroSectionContent({ section, resume }: { section: any; resume: Resume 
         {(content.categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-28 shrink-0 font-medium" style={{ color: BLUE }}>{cat.name}:</span>
-            <span className="text-zinc-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/finance.tsx
+++ b/src/components/preview/templates/finance.tsx
@@ -138,7 +138,7 @@ function FinanceSectionContent({ section, resume }: { section: any; resume: Resu
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: SLATE_800 }}>{cat.name}:</span>
-            <span className="text-slate-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-slate-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/formal.tsx
+++ b/src/components/preview/templates/formal.tsx
@@ -124,7 +124,7 @@ function FormalSectionContent({ section, resume }: { section: any; resume: Resum
         {(content.categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: DARK_GREEN }}>{cat.name}:</span>
-            <span className="text-zinc-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/japanese.tsx
+++ b/src/components/preview/templates/japanese.tsx
@@ -141,7 +141,7 @@ function JapaneseSectionContent({ section, lang }: { section: any; lang?: string
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-normal" style={{ color: PRIMARY }}>{cat.name}</span>
-            <span className="font-light" style={{ color: PRIMARY }}>{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line font-light" style={{ color: PRIMARY }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/legal.tsx
+++ b/src/components/preview/templates/legal.tsx
@@ -152,7 +152,7 @@ function LegalSectionContent({ section, resume }: { section: any; resume: Resume
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="text-sm">
             <span className="font-bold" style={{ color: PRIMARY }}>{cat.name}: </span>
-            <span style={{ color: BODY_TEXT }}>{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line" style={{ color: BODY_TEXT }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/luxe.tsx
+++ b/src/components/preview/templates/luxe.tsx
@@ -152,7 +152,7 @@ function LuxeSectionContent({ section, lang }: { section: any; lang?: string }) 
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-bold" style={{ color: GOLD }}>{cat.name}:</span>
-            <span style={{ color: '#44403c' }}>{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line" style={{ color: '#44403c' }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/magazine.tsx
+++ b/src/components/preview/templates/magazine.tsx
@@ -165,7 +165,7 @@ function MagazineSectionContent({ section, resume }: { section: any; resume: Res
         {categories.map((cat: any) => (
           <div key={cat.id}>
             <p className="mb-1 text-xs font-bold uppercase tracking-wider" style={{ color: ACCENT }}>{cat.name}</p>
-            <p className="text-sm" style={{ color: SECONDARY }}>{cat.skills?.join(' / ')}</p>
+            <p className="whitespace-pre-line text-sm" style={{ color: SECONDARY }}>{cat.skills?.join('\n')}</p>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/medical.tsx
+++ b/src/components/preview/templates/medical.tsx
@@ -138,7 +138,7 @@ function MedicalSectionContent({ section, resume }: { section: any; resume: Resu
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: TEAL_800 }}>{cat.name}:</span>
-            <span className="text-gray-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-gray-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/minimal.tsx
+++ b/src/components/preview/templates/minimal.tsx
@@ -118,7 +118,7 @@ function MinimalSectionContent({ section, lang }: { section: any; lang?: string 
     return (
       <div className="space-y-1">
         {(content.categories || []).map((cat: any) => (
-          <p key={cat.id} className="text-sm text-zinc-600">{cat.skills?.join(' / ')}</p>
+          <p key={cat.id} className="whitespace-pre-line text-sm text-zinc-600">{cat.skills?.join('\n')}</p>
         ))}
       </div>
     );

--- a/src/components/preview/templates/nordic.tsx
+++ b/src/components/preview/templates/nordic.tsx
@@ -132,7 +132,7 @@ function NordicSectionContent({ section, resume }: { section: any; resume: Resum
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-28 shrink-0 font-medium" style={{ color: SLATE_500 }}>{cat.name}:</span>
-            <span className="font-light" style={{ color: SLATE_400 }}>{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line font-light" style={{ color: SLATE_400 }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/professional.tsx
+++ b/src/components/preview/templates/professional.tsx
@@ -147,7 +147,7 @@ function ProfessionalSectionContent({ section, lang }: { section: any; lang?: st
         {categories.map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-semibold" style={{ color: '#1e3a5f' }}>{cat.name}:</span>
-            <span className="text-zinc-600">{cat.skills?.join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{cat.skills?.join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/retro.tsx
+++ b/src/components/preview/templates/retro.tsx
@@ -167,7 +167,7 @@ function RetroSectionContent({ section, resume }: { section: any; resume: Resume
         {categories.map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-32 shrink-0 font-bold" style={{ color: PRIMARY, fontFamily: "'Courier New', monospace" }}>{cat.name}:</span>
-            <span style={{ color: '#57534e' }}>{cat.skills?.join(' \u2022 ')}</span>
+            <span className="whitespace-pre-line" style={{ color: '#57534e' }}>{cat.skills?.join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/scientist.tsx
+++ b/src/components/preview/templates/scientist.tsx
@@ -161,7 +161,7 @@ function ScientistSectionContent({ section, resume }: { section: any; resume: Re
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="text-sm">
             <span className="font-bold italic" style={{ color: PRIMARY }}>{cat.name}: </span>
-            <span style={{ color: BODY_TEXT }}>{(cat.skills || []).join('; ')}</span>
+            <span className="whitespace-pre-line" style={{ color: BODY_TEXT }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/sidebar.tsx
+++ b/src/components/preview/templates/sidebar.tsx
@@ -374,7 +374,7 @@ function MainSectionContent({ section, resume }: { section: any; resume: Resume 
         {categories.map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-28 shrink-0 font-medium text-zinc-700">{cat.name}:</span>
-            <span className="text-zinc-600">{cat.skills?.join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{cat.skills?.join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/swiss.tsx
+++ b/src/components/preview/templates/swiss.tsx
@@ -145,7 +145,7 @@ function SwissSectionContent({ section, lang }: { section: any; lang?: string })
         {((content as SkillsContent).categories || []).map((cat: any) => (
           <div key={cat.id} className="grid grid-cols-[140px_1fr] gap-4 text-sm">
             <span className="font-bold" style={{ color: TEXT }}>{cat.name}</span>
-            <span style={{ color: '#3f3f46' }}>{(cat.skills || []).join(' / ')}</span>
+            <span className="whitespace-pre-line" style={{ color: '#3f3f46' }}>{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/preview/templates/timeline.tsx
+++ b/src/components/preview/templates/timeline.tsx
@@ -131,7 +131,7 @@ function TimelineSectionContent({ section, resume }: { section: any; resume: Res
         {(content.categories || []).map((cat: any) => (
           <div key={cat.id} className="flex text-sm">
             <span className="w-28 shrink-0 font-medium" style={{ color: ACCENT }}>{cat.name}:</span>
-            <span className="text-zinc-600">{(cat.skills || []).join(', ')}</span>
+            <span className="whitespace-pre-line text-zinc-600">{(cat.skills || []).join('\n')}</span>
           </div>
         ))}
       </div>

--- a/src/components/resume/resume-workbench.tsx
+++ b/src/components/resume/resume-workbench.tsx
@@ -32,6 +32,7 @@ import {
   A4_HEIGHT_PX,
   A4_WIDTH_PX,
   calculateResumePagination,
+  collectResumePageBreakCandidates,
   getCombinedPageImageLayout,
 } from "@/lib/resume-export-layout";
 import { contentToJadeResume, jadeResumeToContent } from "@/lib/resume-adapter";
@@ -863,7 +864,12 @@ async function renderResumePagesForExport(resume: Resume, smartOnePage: boolean)
   const { ResumePreview } = await import("@/components/preview/resume-preview");
 
   const measuredHeight = Math.max(measurement.element.scrollHeight, Math.ceil(measurement.element.getBoundingClientRect().height), 1);
-  const { fitScale, pageCount, horizontalOffset } = calculateResumePagination(measuredHeight, smartOnePage);
+  const breakCandidates = collectResumePageBreakCandidates(measurement.element);
+  const { fitScale, pageSlices, horizontalOffset } = calculateResumePagination(
+    measuredHeight,
+    smartOnePage,
+    breakCandidates,
+  );
 
   const container = document.createElement("div");
   container.setAttribute("data-resume-export-pages", "true");
@@ -882,7 +888,7 @@ async function renderResumePagesForExport(resume: Resume, smartOnePage: boolean)
   const roots: Array<ReturnType<typeof createRoot>> = [];
   const pages: HTMLElement[] = [];
 
-  for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+  for (const pageSlice of pageSlices) {
     const page = document.createElement("div");
     Object.assign(page.style, {
       position: "relative",
@@ -890,6 +896,19 @@ async function renderResumePagesForExport(resume: Resume, smartOnePage: boolean)
       height: `${A4_HEIGHT_PX}px`,
       overflow: "hidden",
       background: "#ffffff",
+    });
+
+    const sliceViewport = document.createElement("div");
+    Object.assign(sliceViewport.style, {
+      position: "absolute",
+      left: "0",
+      top: `${pageSlice.topInset}px`,
+      width: `${A4_WIDTH_PX}px`,
+      height: `${Math.min(
+        A4_HEIGHT_PX - pageSlice.topInset,
+        (pageSlice.sourceEnd - pageSlice.sourceStart) * fitScale,
+      )}px`,
+      overflow: "hidden",
     });
 
     const scaleWrapper = document.createElement("div");
@@ -903,9 +922,10 @@ async function renderResumePagesForExport(resume: Resume, smartOnePage: boolean)
     });
 
     const slice = document.createElement("div");
-    slice.style.marginTop = `${-(pageIndex * A4_HEIGHT_PX) / fitScale}px`;
+    slice.style.marginTop = `${-pageSlice.sourceStart}px`;
     scaleWrapper.appendChild(slice);
-    page.appendChild(scaleWrapper);
+    sliceViewport.appendChild(scaleWrapper);
+    page.appendChild(sliceViewport);
     container.appendChild(page);
 
     const root = createRoot(slice);

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,14 +2,43 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function resizeToContent(textarea: HTMLTextAreaElement | null) {
+  if (!textarea) return
+
+  // Reset first so the control can shrink again after text is removed.
+  textarea.style.height = "auto"
+  textarea.style.height = `${textarea.scrollHeight}px`
+}
+
+function Textarea({ className, onInput, ref, value, ...props }: React.ComponentProps<"textarea">) {
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
+
+  const setRef = React.useCallback((node: HTMLTextAreaElement | null) => {
+    textareaRef.current = node
+    if (typeof ref === "function") {
+      ref(node)
+    } else if (ref) {
+      ref.current = node
+    }
+  }, [ref])
+
+  React.useLayoutEffect(() => {
+    resizeToContent(textareaRef.current)
+  }, [value])
+
   return (
     <textarea
+      ref={setRef}
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        "flex field-sizing-content min-h-16 w-full overflow-y-hidden rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
+      value={value}
+      onInput={(event) => {
+        resizeToContent(event.currentTarget)
+        onInput?.(event)
+      }}
       {...props}
     />
   )

--- a/src/lib/resume-export-layout.test.ts
+++ b/src/lib/resume-export-layout.test.ts
@@ -37,6 +37,22 @@ describe("resume export layout", () => {
     expect(pagination.horizontalOffset).toBe(0);
   });
 
+  it("uses safe measured boundaries and adds breathing room above continuation pages", () => {
+    const pagination = calculateResumePagination(1900, false, [1040, 1100, 1140]);
+
+    expect(pagination.pageSlices).toEqual([
+      { sourceStart: 0, sourceEnd: 1100, topInset: 0 },
+      { sourceStart: 1100, sourceEnd: 1900, topInset: 32 },
+    ]);
+  });
+
+  it("does not hide a small overflow beyond the first A4 page", () => {
+    const pagination = calculateResumePagination(A4_HEIGHT_PX + 1, false);
+
+    expect(pagination.pageCount).toBe(2);
+    expect(pagination.pageSlices.at(-1)?.sourceEnd).toBe(A4_HEIGHT_PX + 1);
+  });
+
   it("removes web-card chrome when rendering a resume inside an A4 page", () => {
     const css = buildPagedResumeModeCSS('[data-theme-scope="preview"]');
 

--- a/src/lib/resume-export-layout.ts
+++ b/src/lib/resume-export-layout.ts
@@ -1,16 +1,28 @@
 export const A4_WIDTH_PX = 794;
 export const A4_HEIGHT_PX = 1123;
 
-const PAGE_TOLERANCE_PX = 24;
+const PAGE_TOLERANCE_PX = 0;
 const MIN_READABLE_SMART_ONE_PAGE_SCALE = 0.82;
 const EXPORT_IMAGE_SCALE = 2;
 const PREVIEW_PAGE_GUTTER_PX = 48;
 const MIN_AUTO_PREVIEW_ZOOM = 35;
 const MAX_AUTO_PREVIEW_ZOOM = 90;
+const CONTINUATION_PAGE_TOP_INSET_PX = 32;
+const MIN_BREAK_FILL_RATIO = 0.65;
 
 export type ResumePreviewRenderMode = "standalone" | "paged" | "export";
 
-export function calculateResumePagination(contentHeight: number, smartOnePage: boolean) {
+export type ResumePageSlice = {
+  sourceStart: number;
+  sourceEnd: number;
+  topInset: number;
+};
+
+export function calculateResumePagination(
+  contentHeight: number,
+  smartOnePage: boolean,
+  breakCandidates: number[] = [],
+) {
   const measuredHeight = Math.max(contentHeight, 1);
   const neededScale = measuredHeight > A4_HEIGHT_PX ? A4_HEIGHT_PX / measuredHeight : 1;
   const smartOnePageOverflow = Boolean(smartOnePage && neededScale < MIN_READABLE_SMART_ONE_PAGE_SCALE);
@@ -18,13 +30,145 @@ export function calculateResumePagination(contentHeight: number, smartOnePage: b
   const fitScale = smartOnePageApplied && measuredHeight > A4_HEIGHT_PX
     ? Math.min(1, neededScale)
     : 1;
-  const effectiveHeight = measuredHeight * fitScale;
-  const pageCount = smartOnePageApplied
-    ? 1
-    : Math.max(1, Math.ceil(Math.max(0, effectiveHeight - PAGE_TOLERANCE_PX) / A4_HEIGHT_PX));
+  const pageSlices = smartOnePageApplied
+    ? [{ sourceStart: 0, sourceEnd: measuredHeight, topInset: 0 }]
+    : calculatePageSlices(measuredHeight, breakCandidates);
+  const pageCount = pageSlices.length;
   const horizontalOffset = fitScale < 1 ? (A4_WIDTH_PX * (1 - fitScale)) / 2 : 0;
 
-  return { fitScale, pageCount, horizontalOffset, smartOnePageApplied, smartOnePageOverflow };
+  return {
+    fitScale,
+    pageCount,
+    pageSlices,
+    horizontalOffset,
+    smartOnePageApplied,
+    smartOnePageOverflow,
+  };
+}
+
+function calculatePageSlices(contentHeight: number, breakCandidates: number[]): ResumePageSlice[] {
+  if (contentHeight <= A4_HEIGHT_PX + PAGE_TOLERANCE_PX) {
+    return [{ sourceStart: 0, sourceEnd: contentHeight, topInset: 0 }];
+  }
+
+  const candidates = [...new Set(
+    breakCandidates
+      .filter((value) => Number.isFinite(value) && value > 0 && value < contentHeight)
+      .map((value) => Math.round(value * 100) / 100),
+  )].sort((a, b) => a - b);
+  const slices: ResumePageSlice[] = [];
+  let sourceStart = 0;
+
+  while (sourceStart < contentHeight - PAGE_TOLERANCE_PX) {
+    const topInset = slices.length === 0 ? 0 : CONTINUATION_PAGE_TOP_INSET_PX;
+    const sourceCapacity = A4_HEIGHT_PX - topInset;
+    const targetEnd = sourceStart + sourceCapacity;
+
+    if (targetEnd >= contentHeight - PAGE_TOLERANCE_PX) {
+      slices.push({ sourceStart, sourceEnd: contentHeight, topInset });
+      sourceStart = contentHeight;
+      break;
+    }
+
+    const minimumUsefulBreak = sourceStart + sourceCapacity * MIN_BREAK_FILL_RATIO;
+    const safeEnd = findLastCandidate(candidates, minimumUsefulBreak, targetEnd) ?? targetEnd;
+    slices.push({ sourceStart, sourceEnd: safeEnd, topInset });
+    sourceStart = safeEnd;
+  }
+
+  if (sourceStart < contentHeight) {
+    slices.push({
+      sourceStart,
+      sourceEnd: contentHeight,
+      topInset: slices.length === 0 ? 0 : CONTINUATION_PAGE_TOP_INSET_PX,
+    });
+  }
+
+  return slices.length > 0
+    ? slices
+    : [{ sourceStart: 0, sourceEnd: contentHeight, topInset: 0 }];
+}
+
+function findLastCandidate(candidates: number[], minimum: number, maximum: number) {
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index];
+    if (candidate > maximum) continue;
+    if (candidate >= minimum) return candidate;
+    break;
+  }
+  return undefined;
+}
+
+/**
+ * Finds vertical boundaries between rendered text/blocks. These coordinates let
+ * the preview start the next page between lines instead of cutting a line in half.
+ */
+export function collectResumePageBreakCandidates(root: HTMLElement): number[] {
+  const rootRect = root.getBoundingClientRect();
+  const rootHeight = Math.max(root.scrollHeight, Math.ceil(rootRect.height), 1);
+  const candidates: number[] = [];
+  const textIntervals: Array<{ top: number; bottom: number }> = [];
+
+  const addRect = (rect: DOMRect) => {
+    const top = rect.top - rootRect.top;
+    const bottom = rect.bottom - rootRect.top;
+    if (bottom <= 0 || top >= rootHeight) return;
+    textIntervals.push({ top: Math.max(0, top), bottom: Math.min(rootHeight, bottom) });
+  };
+
+  const nodeFilter = root.ownerDocument.defaultView?.NodeFilter;
+  if (nodeFilter) {
+    const walker = root.ownerDocument.createTreeWalker(root, nodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      if (node.textContent?.trim()) {
+        const range = root.ownerDocument.createRange();
+        range.selectNodeContents(node);
+        Array.from(range.getClientRects()).forEach(addRect);
+        range.detach();
+      }
+      node = walker.nextNode();
+    }
+  }
+
+  const isInsideText = (position: number) => textIntervals.some(
+    ({ top, bottom }) => position > top + 1 && position < bottom - 1,
+  );
+
+  root.querySelectorAll<HTMLElement>("[data-section], [data-section] *").forEach((element) => {
+    const style = root.ownerDocument.defaultView?.getComputedStyle(element);
+    if (!style || style.display === "none" || style.position === "fixed" || style.position === "absolute") return;
+
+    Array.from(element.getClientRects()).forEach((rect) => {
+      const top = rect.top - rootRect.top;
+      const bottom = rect.bottom - rootRect.top;
+      if (top > 0 && top < rootHeight && !isInsideText(top)) candidates.push(top);
+      if (bottom > 0 && bottom < rootHeight && !isInsideText(bottom)) candidates.push(bottom);
+    });
+  });
+
+  const mergedTextIntervals = textIntervals
+    .sort((a, b) => a.top - b.top)
+    .reduce<Array<{ top: number; bottom: number }>>((merged, interval) => {
+      const previous = merged.at(-1);
+      if (!previous || interval.top > previous.bottom + 0.5) {
+        merged.push({ ...interval });
+      } else {
+        previous.bottom = Math.max(previous.bottom, interval.bottom);
+      }
+      return merged;
+    }, []);
+
+  for (let index = 0; index < mergedTextIntervals.length - 1; index += 1) {
+    const current = mergedTextIntervals[index];
+    const next = mergedTextIntervals[index + 1];
+    if (next.top > current.bottom) {
+      candidates.push((current.bottom + next.top) / 2);
+    }
+  }
+
+  return [...new Set(candidates.map((value) => Math.round(value * 2) / 2))]
+    .sort((a, b) => a - b);
 }
 
 export function buildPagedResumeModeCSS(scopeSelector: string) {


### PR DESCRIPTION
## 修复的 Bug

- 左侧编辑器的亮点、技术/关键词列表使用单行输入框，长文本无法自动增高，编辑时只能横向滚动。
- 简历超过一页后按固定 A4 高度直接裁切，可能截断文字或区块；仅轻微超页时还可能遗漏末尾内容。
- 技能分类包含多个技术/关键词时，多个模板使用逗号、斜杠或竖线连接，无法按条目逐行阅读。

## 主要改动

- 为通用 Textarea 增加可靠的自动增高和缩回逻辑，并将列表编辑项改为多行文本框。
- 根据实际文字行和区块边界计算安全分页点，续页保留顶部空间。
- 让实时预览、PDF 和图片导出共用同一套分页切片。
- 将原先使用分隔符的技能模板统一改为逐行显示关键词。

## 验证

- `npm test`：43 个测试文件、178 项测试通过。
- `npm run build`：生产构建通过。
- 浏览器手动验证：长输入框自动增高、技能逐行显示、两页内容连续且续页留白正常。