### PR TITLE
fix: preserve skill categories after saving

### DIFF
--- a/src/lib/resume-adapter.test.ts
+++ b/src/lib/resume-adapter.test.ts
@@ -235,6 +235,27 @@ describe("resume content adapter", () => {
     ]);
   });
 
+  it("keeps skill categories isolated when the flattened skills are reordered", () => {
+    const jadeResume = contentToJadeResume({ ...baseResume, skills: ["TypeScript"] });
+    const skills = jadeResume.sections.find((section) => section.type === "skills")!;
+    skills.content = {
+      categories: [
+        { id: "frontend", name: "前端", skills: ["TypeScript", "React"] },
+        { id: "tools", name: "工具", skills: ["Git", "Docker"] },
+      ],
+    } satisfies SkillsContent;
+    const savedContent = jadeResumeToContent(jadeResume);
+    savedContent.skills = ["Git", "Docker", "TypeScript", "React"];
+
+    const reopened = contentToJadeResume(savedContent);
+    const reopenedSkills = reopened.sections.find((section) => section.type === "skills")?.content as SkillsContent;
+
+    expect(reopenedSkills.categories).toEqual([
+      { id: "frontend", name: "前端", skills: ["TypeScript", "React"] },
+      { id: "tools", name: "工具", skills: ["Git", "Docker"] },
+    ]);
+  });
+
   it("maps imported custom titled sections into editor custom modules", () => {
     const jadeResume = contentToJadeResume({
       ...baseResume,

--- a/src/lib/resume-adapter.test.ts
+++ b/src/lib/resume-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { contentToJadeResume, jadeResumeToContent } from "./resume-adapter";
 import type { ResumeContent } from "./types";
-import type { PersonalInfoContent, WorkExperienceContent } from "@/types/resume";
+import type { PersonalInfoContent, SkillsContent, WorkExperienceContent } from "@/types/resume";
 
 const baseResume: ResumeContent = {
   basics: {
@@ -214,6 +214,25 @@ describe("resume content adapter", () => {
 
     expect(content.experiences[0].logo).toBe(logo);
     expect(content.projects[0].logo).toBe(logo);
+  });
+
+  it("keeps skill category keywords isolated after saving and reopening", () => {
+    const jadeResume = contentToJadeResume({ ...baseResume, skills: ["TypeScript"] });
+    const skills = jadeResume.sections.find((section) => section.type === "skills")!;
+    skills.content = {
+      categories: [
+        { id: "frontend", name: "前端", skills: ["TypeScript", "React"] },
+        { id: "tools", name: "工具", skills: ["Git", "Docker"] },
+      ],
+    } satisfies SkillsContent;
+
+    const reopened = contentToJadeResume(jadeResumeToContent(jadeResume));
+    const reopenedSkills = reopened.sections.find((section) => section.type === "skills")?.content as SkillsContent;
+
+    expect(reopenedSkills.categories).toEqual([
+      { id: "frontend", name: "前端", skills: ["TypeScript", "React"] },
+      { id: "tools", name: "工具", skills: ["Git", "Docker"] },
+    ]);
   });
 
   it("maps imported custom titled sections into editor custom modules", () => {

--- a/src/lib/resume-adapter.ts
+++ b/src/lib/resume-adapter.ts
@@ -366,6 +366,8 @@ function mergeEditorSection(saved: ResumeSection, generated?: ResumeSection): Re
       const previous = saved.content as SkillsContent;
       const next = generated.content as SkillsContent;
       if (!next.categories.length) return saved;
+      const nextSkills = next.categories.flatMap((category) => category.skills);
+      if (JSON.stringify(previous.categories.flatMap((category) => category.skills)) === JSON.stringify(nextSkills)) return saved;
       const [firstCategory, ...otherCategories] = previous.categories;
       return {
         ...saved,
@@ -374,7 +376,7 @@ function mergeEditorSection(saved: ResumeSection, generated?: ResumeSection): Re
           categories: [
             {
               ...(firstCategory ?? { id: generateId("skills"), name: "核心技能" }),
-              skills: next.categories.flatMap((category) => category.skills),
+              skills: nextSkills,
             },
             ...otherCategories,
           ],

--- a/src/lib/resume-adapter.ts
+++ b/src/lib/resume-adapter.ts
@@ -367,7 +367,8 @@ function mergeEditorSection(saved: ResumeSection, generated?: ResumeSection): Re
       const next = generated.content as SkillsContent;
       if (!next.categories.length) return saved;
       const nextSkills = next.categories.flatMap((category) => category.skills);
-      if (JSON.stringify(previous.categories.flatMap((category) => category.skills)) === JSON.stringify(nextSkills)) return saved;
+      const previousSkills = new Set(previous.categories.flatMap((category) => category.skills));
+      if (previousSkills.size === new Set(nextSkills).size && nextSkills.every((skill) => previousSkills.has(skill))) return saved;
       const [firstCategory, ...otherCategories] = previous.categories;
       return {
         ...saved,


### PR DESCRIPTION
## Summary

- Preserve the saved category structure when its flattened skill list already matches the generated list.

- Add a regression test covering multiple skill categories across a save and reopen cycle.

## Root cause

The resume stores both the editor's skill categories and a flattened skill list for compatibility. When reopening a saved resume, the adapter copied the flattened list into the first category while keeping the remaining categories unchanged. This duplicated keywords from later categories in the first category.

## Testing

`npm test -- src/lib/resume-adapter.test.ts`

Closes #11